### PR TITLE
Refactor create project to create other section

### DIFF
--- a/backend/src/controllers/project.ts
+++ b/backend/src/controllers/project.ts
@@ -7,7 +7,7 @@
  */
 
 import * as projectServices from "../services/project";
-import { PrismaClient, Project } from "../../generated/prisma";
+import { PrismaClient, Project, Section } from "../../generated/prisma";
 
 const MAX_PROJECTS = 100;
 
@@ -197,11 +197,11 @@ const getProjectByName =
  * @returns An asynchronous function:
  *    - @param name - The name of the project.
  *    - @param color - The hex code of the color assigned to this project
- *    - @returns A Promise resolving to the created `Project` on success, or an `Error` if creation fails.
+ *    - @returns A Promise resolving to a tuple of the created `Project` and `Section` on success, or an `Error` if creation fails.
  */
 const createProject =
 	(prisma: PrismaClient) =>
-	async (name: string, color: string): Promise<Project | Error> => {
+	async (name: string, color: string): Promise<[Project,Section] | Error> => {
 		try {
 			//verify the is room for more projects
 			const size = await projectServices.getProjectCount(prisma);

--- a/backend/src/documentation/project.ts
+++ b/backend/src/documentation/project.ts
@@ -24,11 +24,17 @@
  *                 example: "#f00"
  *     responses:
  *       200:
- *          description: Project successfully created
- *          content:
- *              application/json:
- *                  schema:
- *                      $ref: "#/components/schemas/Project"
+ *         description: Project and default \"Other\" section successfully created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               minItems: 2
+ *               maxItems: 2
+ *               items:
+ *                 allOf:
+ *                   - $ref: "#/components/schemas/Project"
+ *                   - $ref: "#/components/schemas/Section"
  *       400:
  *          description: Bad Request
  *          content:

--- a/backend/src/services/project.ts
+++ b/backend/src/services/project.ts
@@ -3,7 +3,7 @@
  * Provides database access methods for Project entities using Prisma.
  */
 
-import { PrismaClient, Project } from "../../generated/prisma";
+import { PrismaClient, Project, Section } from "../../generated/prisma";
 
 const deleteProjectById =
 	(prisma: PrismaClient) =>
@@ -72,21 +72,34 @@ const getAllProjects = async (prisma: PrismaClient): Promise<Project[]> => {
 };
 
 /**
- * Creates a new project with the given name and color.
+ * Creates a new project and automatically creates an "Other" section for it.
  *
  * @param prisma - The Prisma client instance.
- * @returns A function that accepts project `name` and `color` and returns the created Project.
+ * @returns A function that accepts project `name` and `color` and returns a tuple of the created Project and Section.
  */
 const createProject =
 	(prisma: PrismaClient) =>
-	async (name: string, color: string): Promise<Project> => {
-		const project = await prisma.project.create({
-			data: {
-				name,
-				color
-			}
+	async (name: string, color: string): Promise<[Project, Section]> => {
+		return await prisma.$transaction(async (transaction) => {
+			//create the Project
+			const project = await transaction.project.create({
+				data: {
+					name,
+					color,
+				},
+			});
+
+			//crate the Other Section corresponding to the Project
+			const section = await transaction.section.create({
+				data: {
+					name: "Other",
+					is_other: true,
+					project_id: project.id,
+				},
+			});
+
+			return [project, section];
 		});
-		return project;
 	};
 
 /**


### PR DESCRIPTION
## Summary
Automatically add "Other" `Section` of a project when said project is created

## Implementation Notes
- Refactored `createProject` function to be a transaction that creates the `Project` and "Other" `Section` at the same time.
- Refactored `createProject` controller to return a tuple of the created `Project` and `Section`.
  - Changed documentation to reflect this.

## Related Issues / PRs
- Closes #129

## Checklist
- [x] Feature is scoped to a single purpose
- [x] Code is tested (unit/integration as needed)
- [x] Code is linted and follows project conventions
- [x] All acceptance criteria are met
- [x] Documentation updated if applicable
- [x] Changelog updated
- [x] Files changed/added have a header comment
- [x] All changed/added function have header comments
- [x] Any backend status use the status-code-enum dependency