### PR TITLE
Add instructions to add pre-push hook to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Added
-
+- Add optional steps to add a pre-push hook
 - API endpoints:
   - Create projects
   - Get projects by ID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Added
-- Add optional steps to add a pre-push hook
+- Optional wiki steps to add a pre-push hook
 - API endpoints:
   - Create projects
   - Get projects by ID

--- a/WIKI.md
+++ b/WIKI.md
@@ -94,7 +94,8 @@ There is a custom script `prepare:test` in the backend that is utilized in order
 # Exit immediately if any command returns a non-zero status
 set -e
 
-# Log to tmp folder instead of .git/hooks
+# Log to root tmp folder
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 mkdir -p "$REPO_ROOT/tmp"
 echo "$(date) Setting up backend imports for testing mode..." >> "$REPO_ROOT/tmp/git-hooks.log"
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -83,7 +83,7 @@ There is a custom script `prepare:test` in the backend that is utilized in order
 1. Open the `.git` folder in the root
     - This folder may be hidden. Be sure to set up your device to see hidden files.
     - If the folder is still not there, run `git init` in the root in the terminal.
-1. Rename `pre-push.sample` to `pre-push`
+1. Rename `pre-push.sample` to `pre-push` in the `hooks` folder
 1. Replace the content of `pre-push` with the following:
     1. The hook should work correctly, if you see a new log line in `.git/tmp/git-hooks.log`
 ```

--- a/WIKI.md
+++ b/WIKI.md
@@ -78,6 +78,27 @@ http://localhost:3000/api
 
 - This page shows all available API endpoints, request/response schemas, and examples.
 
+### 3.2 Set up Git pre-push hook (Optional)
+There is a custom script `INSERT SCRIPT NAME HERE` in the backend that is utlized in order to verify the application works in development mode. It is suggested to set up a pre-push hook in order to not need to remember to run this script manually. Below are the instructions to set up this hook.
+1. Open the `.git` folder in the root
+    - This folder may be hidden. Be sure to set up your device to see hidden files.
+    - If the folder is still not there, run `git init` in the root in the terminal.
+1. Rename `pre-push.sample` to `pre-push`
+1. Replace the content of `pre-push` with the following:
+    1. The hook should work correctly, if you see a new log line in `.git/tmp/git-hooks.log`
+```
+#!/bin/sh
+# Exit immediately if any command returns a non-zero status
+set -e
+
+echo "$(date) Setting up backend imports for testing mode..." >> .git/tmp/git-hooks.log
+npm run prepare:test --prefix backend
+```
+4. If you are using macOS or Linux, run the following to make the hook executable
+```
+chmod +x .git/hooks/pre-push
+```
+5. Test the hook by making a dummy commit/push and checking the the logs.
 ## 4. Frontend Setup
 
 1. If using VSCode:

--- a/WIKI.md
+++ b/WIKI.md
@@ -94,15 +94,17 @@ There is a custom script `prepare:test` in the backend that is utilized in order
 # Exit immediately if any command returns a non-zero status
 set -e
 
-echo "$(date) Setting up backend imports for testing mode..." >> .git/tmp/git-hooks.log
-npm run prepare:test --prefix backend
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "$(date) Setting up backend imports for testing mode..." >> "$REPO_ROOT/.git/hooks/git-hooks.log"
+npm run prepare:test --prefix "$REPO_ROOT/backend"
 ```
 4. Run the following to make the hook executable
 ```
 chmod +x .git/hooks/pre-push
 ```
 
-5. Verify the hook execuable was set up correctly by running
+5. Verify the hook executable was set up correctly by running
 ```
 ls -l .git/hooks/pre-push
 ```

--- a/WIKI.md
+++ b/WIKI.md
@@ -94,9 +94,11 @@ There is a custom script `prepare:test` in the backend that is utilized in order
 # Exit immediately if any command returns a non-zero status
 set -e
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Log to tmp folder instead of .git/hooks
+mkdir -p "$REPO_ROOT/tmp"
+echo "$(date) Setting up backend imports for testing mode..." >> "$REPO_ROOT/tmp/git-hooks.log"
 
-echo "$(date) Setting up backend imports for testing mode..." >> "$REPO_ROOT/.git/hooks/git-hooks.log"
+# Run backend command
 npm run prepare:test --prefix "$REPO_ROOT/backend"
 ```
 4. Run the following to make the hook executable

--- a/WIKI.md
+++ b/WIKI.md
@@ -1,4 +1,4 @@
-# Overview test
+# Overview
 
 This project is a full-stack application with a React frontend and a Node.js / Express backend using TypeScript.
 
@@ -80,6 +80,9 @@ http://localhost:3000/api
 
 ### 3.2 Set up Git pre-push hook (Optional)
 There is a custom script `prepare:test` in the backend that is utilized in order to verify the application works in development mode. It is suggested to set up a pre-push hook in order to not need to remember to run this script manually. Below are the instructions to set up this hook.
+
+**Disclaimer:** This will **NOT** work if you are using windows powershell. Git bash should be used instead.
+
 1. Open the `.git` folder in the root
     - This folder may be hidden. Be sure to set up your device to see hidden files.
     - If the folder is still not there, run `git init` in the root in the terminal.
@@ -94,10 +97,22 @@ set -e
 echo "$(date) Setting up backend imports for testing mode..." >> .git/tmp/git-hooks.log
 npm run prepare:test --prefix backend
 ```
-4. If you are using macOS or Linux, run the following to make the hook executable
+4. Run the following to make the hook executable
 ```
 chmod +x .git/hooks/pre-push
 ```
+
+5. Verify the hook execuable was set up correctly by running
+```
+ls -l .git/hooks/pre-push
+```
+This should be printed in the console
+```
+-rwxr-xr-x (other stuff is here...)
+```
+
+
+
 5. Test the hook by making a dummy commit/push and checking the the logs.
 ## 4. Frontend Setup
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -1,4 +1,4 @@
-# Overview
+# Overview test
 
 This project is a full-stack application with a React frontend and a Node.js / Express backend using TypeScript.
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -79,7 +79,7 @@ http://localhost:3000/api
 - This page shows all available API endpoints, request/response schemas, and examples.
 
 ### 3.2 Set up Git pre-push hook (Optional)
-There is a custom script `INSERT SCRIPT NAME HERE` in the backend that is utlized in order to verify the application works in development mode. It is suggested to set up a pre-push hook in order to not need to remember to run this script manually. Below are the instructions to set up this hook.
+There is a custom script `prepare:test` in the backend that is utilized in order to verify the application works in development mode. It is suggested to set up a pre-push hook in order to not need to remember to run this script manually. Below are the instructions to set up this hook.
 1. Open the `.git` folder in the root
     - This folder may be hidden. Be sure to set up your device to see hidden files.
     - If the folder is still not there, run `git init` in the root in the terminal.

--- a/backend/src/requestHandlers/project.ts
+++ b/backend/src/requestHandlers/project.ts
@@ -7,7 +7,7 @@
  * for success, validation errors, and controller-level errors.
  */
 import * as projectController from "../controllers/project";
-import * as utils from "../utils";
+import * as utils from "../utils.js";
 import { Request, Response } from "express";
 import { StatusCode } from "status-code-enum";
 

--- a/backend/src/requestHandlers/section.ts
+++ b/backend/src/requestHandlers/section.ts
@@ -8,7 +8,7 @@
  */
 
 import * as sectionController from "../controllers/section";
-import * as utils from "../utils";
+import * as utils from "../utils.js";
 import { Request, Response } from "express";
 import { StatusCode } from "status-code-enum";
 /**

--- a/backend/src/router.ts
+++ b/backend/src/router.ts
@@ -9,10 +9,10 @@
 import * as project from "./requestHandlers/project";
 import * as section from "./requestHandlers/section";
 
-import * as utils from "./utils";
+import * as utils from "./utils.js";
 import { Express } from "express";
 import cors from "cors";
-import { port } from "./server";
+import { port } from "./server.js";
 import swaggerDocs from "./swagger.js";
 
 export default (app: Express) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,3 +31,4 @@ export function App(): React.ReactElement {
 }
 
 export default App;
+// dummy commit

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,4 +31,3 @@ export function App(): React.ReactElement {
 }
 
 export default App;
-// dummy commit


### PR DESCRIPTION
## Summary
To reduce the amount of times people need to manually run the `prepare:test` in order to verify the repo stays in development mode, a pre-push script has been considered to do this automatically when the user pushes to any branch. Unfortunately, this requires the `.git` folder in the root of the project, which is ignored by the repo.

Since this is technically QoL feature that is not required, I added this as an optional step in the `WIKI.md` when setting up the project.

## Steps to step
1. Follow the newly added instructions in the wiki
2. Verify all the instructions are correct and understandable.


## Related Issues / PRs
- Closes #95

## Checklist
- [x] Bug is reproducible and verified
- [x] Fix addresses the root cause, not just symptoms
- [x] No new errors or regressions introduced
- [x] Tests added or updated as needed
- [x] Linting and formatting pass
- [x] Documentation updated (if needed)
- [x] Changelog updated
- [x] Files changed/added have a header comment
- [x] All changed/added function have header comments
- [x] Any backend status use the `status-code-enum` dependency