### PR TITLE
Add pr num changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -74,3 +74,5 @@ npm run test -- taskController.test.js
 - [ ] Files changed/added have a header comment
 - [ ] All changed/added function have header comments
 - [ ] Any backend status use the `status-code-enum` dependency
+- [ ] Add PR number next to new changelog items
+

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -88,3 +88,4 @@ _As a product manager, I want to filter tasks by priority so I can quickly ident
 - [ ] Files changed/added have a header comment
 - [ ] All changed/added function have header comments
 - [ ] Any backend status use the `status-code-enum` dependency
+- [ ] Add PR number next to new changelog items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
   - Get all sections with a project by its id (#128)
   - Update the name of a section (#135)
   - Update the project of a section (#135)
-  - Get all sections within the database
-- Schema documentation added to the Wiki
+  - Get all sections within the database (#128)
+- Schema documentation added to the Wiki (#117)
 - Scripts to easily modify the database for debugging (#115)
 - Swagger API documentation (#91)
 - Util scripts to configure for testing and running build (#94)


### PR DESCRIPTION
## Summary

1. Add PR numbers next to a change in the change log
2. Add a rule in PR templates to verify PR number is added


## Testing Steps

1. Verify all pr numbers to PR changs are accurate
2. Verify all PR templates have the PR number rule
## Related Issues / PRs

- Closes #122

## Checklist

- [x] Bug is reproducible and verified
- [x] Fix addresses the root cause, not just symptoms
- [x] No new errors or regressions introduced
- [x] Tests added or updated as needed
- [x] Linting and formatting pass
- [x] Documentation updated (if needed)
- [x] Changelog updated
- [x] Files changed/added have a header comment
- [x] All changed/added function have header comments
- [x] Any backend status use the `status-code-enum` dependency
- [x] Add PR number next to new changelog items