### PR TITLE
Add dockerfile and docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /build/
 
 COPY frontend/ /build/frontend/
 COPY backend/ /build/backend/
-COPY docker/ /build/docker/
+COPY docker/ /docker/
+COPY eslint.config.ts /build/
 COPY package.json /build/
 COPY .prettierrc /build/
 
@@ -12,7 +13,7 @@ RUN npm install
 RUN npm install frontend/
 RUN npm install backend/
 
-ENTRYPOINT ["/build/docker/entrypoint.sh"]
+ENTRYPOINT ["/docker/entrypoint.sh"]
 
 FROM node:alpine AS frontend
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:alpine AS root
+
+WORKDIR /build/
+
+COPY frontend/ /build/frontend/
+COPY backend/ /build/backend/
+COPY docker/ /build/docker/
+COPY package.json /build/
+COPY .prettierrc /build/
+
+RUN npm install
+RUN npm install frontend/
+RUN npm install backend/
+
+ENTRYPOINT ["/build/docker/entrypoint.sh"]
+
+FROM node:alpine AS frontend
+
+WORKDIR /build/
+
+COPY frontend/ /build/
+COPY docker/ /docker/
+
+RUN npm install
+
+ENTRYPOINT ["/docker/entrypoint.sh"]
+
+FROM node:alpine AS backend
+
+WORKDIR /build/
+
+COPY backend/ /build/
+COPY docker/ /docker/
+
+RUN npm install
+
+ENTRYPOINT ["/docker/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       target: root
     volumes:
+      - .:/build
       - /build/node_modules
       - /build/frontend/node_modules
       - /build/backend/node_modules
@@ -14,11 +15,15 @@ services:
       context: .
       target: backend
     volumes:
+      - .:/build
       - /build/node_modules
+      - /build/backend/node_modules
   frontend:
     image: productivity-app/frontend
     build:
       context: .
       target: frontend
     volumes:
+      - .:/build
       - /build/node_modules
+      - /build/frontend/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  root:
+    image: productivity-app/root
+    build:
+      context: .
+      target: root
+  backend:
+    image: productivity-app/backend
+    build:
+      context: .
+      target: backend
+  frontend:
+    image: productivity-app/frontend
+    build:
+      context: .
+      target: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - .:/build
       - /build/node_modules
       - /build/backend/node_modules
+    networks:
+      - appnet
   frontend:
     image: productivity-app/frontend
     build:
@@ -27,3 +29,10 @@ services:
       - .:/build
       - /build/node_modules
       - /build/frontend/node_modules
+    networks:
+      - appnet
+
+networks:
+  appnet:
+    name: productivity-app-network
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,24 @@
-version: "3.8"
 services:
   root:
     image: productivity-app/root
     build:
       context: .
       target: root
+    volumes:
+      - /build/node_modules
+      - /build/frontend/node_modules
+      - /build/backend/node_modules
   backend:
     image: productivity-app/backend
     build:
       context: .
       target: backend
+    volumes:
+      - /build/node_modules
   frontend:
     image: productivity-app/frontend
     build:
       context: .
       target: frontend
+    volumes:
+      - /build/node_modules

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ $# -gt 0 ]; then
+    exec $@
+fi


### PR DESCRIPTION
## Summary
Adds dockerfile and docker compose for containerized development

## User Story
*As a developer, I want to develop using a container so that my development and testing is consistent with that of any other person.*

## Testing Steps
<!-- Instructions for reviewing or testing this feature locally -->

1. Checkout this branch
2. Ensure you have docker and docker-compose installed
3. Run `docker compose build` to build the images
4. Run any of the images `docker run productivity-app/YOUR_TARGET_HERE -- YOUR_COMMAND_HERE`
  * Example: `docker run productivity-app/root -- npm run build`
5. Expose [ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/) or [mount-points](https://docs.docker.com/engine/storage/volumes/) through your docker run command

## Example Usage
* `docker run -- npm run build`
Builds the production version of the codebase into `./dist`
*  `docker run -p 5173:5173 productivity-app/frontend -- npm run dev -- --host`
 Runs the frontend code in development mode while exposing the development port to the host

## Related Issues / PRs
- Closes #50 

## Checklist
- [ ] Feature is scoped to a single purpose
- [ ] Code is tested (unit/integration as needed)
- [ ] Code is linted and follows project conventions
- [ ] All acceptance criteria are met
- [ ] Documentation updated if applicable
- [ ] Changelog updated