### PR TITLE
Refactor `change-imports.ts` to be less error prone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -70,9 +70,9 @@ npm run test -- taskController.test.js
 - [ ] Tests added or updated as needed
 - [ ] Linting and formatting pass
 - [ ] Documentation updated (if needed)
-- [ ] Changelog updated
 - [ ] Files changed/added have a header comment
 - [ ] All changed/added function have header comments
 - [ ] Any backend status use the `status-code-enum` dependency
+- [ ] Changelog updated
 - [ ] Add PR number next to new changelog items
 

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -84,8 +84,8 @@ _As a product manager, I want to filter tasks by priority so I can quickly ident
 - [ ] Code is linted and follows project conventions
 - [ ] All acceptance criteria are met
 - [ ] Documentation updated if applicable
-- [ ] Changelog updated
 - [ ] Files changed/added have a header comment
 - [ ] All changed/added function have header comments
 - [ ] Any backend status use the `status-code-enum` dependency
+- [ ] Changelog updated
 - [ ] Add PR number next to new changelog items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Basic project display (#127)
 
 ### Changed
-
+- `change-imports.ts` to accept directories and change imports inside said directories (#159)
 - Project plan more to include more detail in terms of sorting, filters, and the inclusion of a "today" view. (#116)
 - `seed-db.ts` updated to create a project called **Other**. (#117)
 

--- a/backend/scripts/change-imports.ts
+++ b/backend/scripts/change-imports.ts
@@ -14,20 +14,14 @@ if (!["test", "build"].includes(target)) {
 const map: Record<string, { test?: string; build?: string }> = {
 	"src/server": { test: "", build: "js" },
 	"src/utils": { test: "", build: "js" },
-	"tests/src/utils": { test: "", build: "js" },
-	"src/requestHandlers/project": { test: "", build: "js" },
-	"src/controllers/project": { test: "", build: "js" },
-	"src/services/project": { test: "", build: "js" },
+	"src/requestHandlers/": { test: "", build: "js" },
+	"src/controllers/": { test: "", build: "js" },
+	"src/services/": { test: "", build: "js" },
 	"src/requestHandlers/section": { test: "", build: "js" },
-	"src/controllers/section": { test: "", build: "js" },
-	"src/services/section": { test: "", build: "js" },
-	"tests/src/controllers/project": { test: "", build: "js" },
-	"tests/src/controllers/section": { test: "", build: "js" },
-	"tests/src/requestHandlers/project": { test: "", build: "js" },
-	"tests/src/requestHandlers/section": { test: "", build: "js" },
-
+	"tests/src/": { test: "", build: "js" },
 };
-
+// tests/src/
+// tests/server
 const importRegex = /(from\s+["'])(\.{1,2}\/[^"']+?)(?:\.(ts|js))?(["'])/g;
 
 function processFile(filePath: string) {
@@ -47,6 +41,8 @@ function processFile(filePath: string) {
 				.relative(process.cwd(), absImportPath)
 				.replace(/\\/g, "/");
 
+			
+
 			// check if this resolved path is in the map
 			const rule = map[relImportPath];
 			if (rule) {
@@ -56,6 +52,14 @@ function processFile(filePath: string) {
 						? `${prefix}${importPath}${suffix}`
 						: `${prefix}${importPath}.${ext}${suffix}`;
 				return newImport;
+			}
+
+			//check if the current directory matches one in the map
+			for (const [key, rule] of Object.entries(map)) {
+				if (key.endsWith("/") && relImportPath.startsWith(key.slice(0, -1))) {
+					const ext = rule[target];
+					return ext === "" ? `${prefix}${importPath}${suffix}` : `${prefix}${importPath}.${ext}${suffix}`;
+				}
 			}
 
 			// untouched if not in map


### PR DESCRIPTION
## Summary

Fixed an issue in change-imports.ts where developers had to manually update the import path map whenever new files were added. The script now supports directory paths where all files within that directory will have their imports updated automatically.

## Testing Steps

<!-- How reviewers can verify the fix -->
1. Go to the `backend` directory
1. Run `prepare:test`
1. Run the `dev` script
1. Verify you can make backend calls through swagger
1. Run `prepare:build`, `build`, and `start` scripts
1. Verify the backend build is running successfully

## Related Issues / PRs

- Closes #154

## Checklist

- [x] Bug is reproducible and verified
- [x] Fix addresses the root cause, not just symptoms
- [x] No new errors or regressions introduced
- [x] Tests added or updated as needed
- [x] Linting and formatting pass
- [x] Documentation updated (if needed)
- [x] Files changed/added have a header comment
- [x] All changed/added function have header comments
- [x] Any backend status use the `status-code-enum` dependency
- [x] Changelog updated
- [x] Add PR number next to new changelog items